### PR TITLE
leanbuild -> ottrpal

### DIFF
--- a/01-intro.Rmd
+++ b/01-intro.Rmd
@@ -1,6 +1,6 @@
 
 ```{r, include = FALSE}
-leanbuild::set_knitr_image_path()
+ottrpal::set_knitr_image_path()
 ```
 
 # Introduction

--- a/02-chapter_of_course.Rmd
+++ b/02-chapter_of_course.Rmd
@@ -4,7 +4,7 @@
 Every chapter needs to start out with this chunk of code:
 
 ```{r, include = FALSE}
-leanbuild::set_knitr_image_path()
+ottrpal::set_knitr_image_path()
 ```
 
 ## Learning Objectives
@@ -65,7 +65,7 @@ dev.off()
 How to include a Google slide. It's simplest to use the `leanbuild` package:
 
 ```{r, fig.align='center', echo = FALSE, fig.alt= "Major point!! example image"}
-leanbuild::include_slide("https://docs.google.com/presentation/d/1YmwKdIy9BeQ3EShgZhvtb3MgR8P6iDX4DfFD65W_gdQ/edit#slide=id.gcc4fbee202_0_141")
+ottrpal::include_slide("https://docs.google.com/presentation/d/1YmwKdIy9BeQ3EShgZhvtb3MgR8P6iDX4DfFD65W_gdQ/edit#slide=id.gcc4fbee202_0_141")
 ```
 
 But if you have the slide or some other image locally downloaded you can also use html like this:


### PR DESCRIPTION
<!--This PR Template was modified from https://github.com/AlexsLemonade/OpenPBTA-analysis/blob/master/.github/PULL_REQUEST_TEMPLATE.md-->

### Purpose/implementation Section

#### What changes are being implemented in this Pull Request?



#### What was your approach?



#### What GitHub issue does your pull request address?



### Tell potential reviewers what kind of feedback you are soliciting.



### New Content Checklist

- [ ] New content/chapter is in an Rmd file with [this kind of format and headers](https://github.com/jhudsl/DaSL_Course_Template_Bookdown/blob/main/02-chapter_of_course.Rmd).

- [ ] New content/chapter contains [Learning Objectives and are in the correct format](https://github.com/jhudsl/DaSL_Course_Template_Bookdown/wiki/Setting-up-images-and-graphics#learning-objectives-formatting).

- [ ] [Bookdown successfully re-renders and any new content files have been added to the _bookdown.yml](https://github.com/jhudsl/DaSL_Course_Template_Bookdown/wiki/Publishing-with-Bookdown).

- [ ] Spell check runs successfully in [Github actions style-n-check](https://github.com/jhudsl/DaSL_Course_Template_Bookdown/wiki/How-to-set-up-and-customize-GitHub-actions-robots#spell-check)).

- [ ] Any newly necessary packages that are needed have been added to the [Dockerfile and image](https://github.com/jhudsl/DaSL_Course_Template_Bookdown/wiki/Using-Docker#adding-packages-to-the-dockerfile).

- [ ] Images are in the [correct format for rendering](https://github.com/jhudsl/DaSL_Course_Template_Bookdown/wiki/Setting-up-images-and-graphics#adding-images-and-graphics-in-text).

- [ ] Every new image has [alt text and is in a Google Slide](https://github.com/jhudsl/DaSL_Course_Template_Bookdown/wiki/Setting-up-images-and-graphics#accessibility).

- [ ] Each slide is described in the notes of the slide so learners relying on a screen reader can access the content. See https://lastcallmedia.com/blog/accessible-comics for more guidance on this.

- [ ] The color palette choices of the slide are contrasted in a way that is friendly to those with color vision deficiencies.
You can check this using [Color Oracle](https://colororacle.org/).
